### PR TITLE
Preserve Explorer list state across navigation

### DIFF
--- a/SportLink/SportLink/App/VuePrincipale.swift
+++ b/SportLink/SportLink/App/VuePrincipale.swift
@@ -51,8 +51,7 @@ struct VuePrincipale: View {
                     .environmentObject(activitesVM)
                     .environmentObject(session)
             case .explorer:
-                ExplorerVue(utilisateur: .constant(mockUtilisateur))
-                    .environmentObject(serviceEmplacements)
+                ExplorerVue(utilisateur: .constant(mockUtilisateur), serviceEmplacements: serviceEmplacements)
                     .environmentObject(activitesVM)
                     .environmentObject(appVM)
             case .creer:

--- a/SportLink/SportLink/Navigation/Explore/Views/ExplorerListeVue.swift
+++ b/SportLink/SportLink/Navigation/Explore/Views/ExplorerListeVue.swift
@@ -10,22 +10,15 @@ import SwiftUI
 struct ExplorerListeVue: View {
     @EnvironmentObject var activitesVM: ActivitesVM
     @EnvironmentObject var appVM: AppVM
-    @StateObject private var vm: ExplorerListeVM
+    @EnvironmentObject private var vm: ExplorerListeVM
     @FocusState private var estEnTrainDeChercher: Bool
     @State private var afficherFiltreOverlay = false
     @State private var activiteAffichantInfo: Activite.ID? = nil
-    
+
     @Binding var utilisateur: Utilisateur
-    
-    init(
-        utilisateur: Binding<Utilisateur>,
-        serviceEmplacements: DonneesEmplacementService
-    ) {
+
+    init(utilisateur: Binding<Utilisateur>) {
         self._utilisateur = utilisateur
-        self._vm = StateObject(wrappedValue: ExplorerListeVM(
-            serviceEmplacements: serviceEmplacements,
-            serviceActivites: ServiceActivites()
-        ))
     }
     
     var body: some View {
@@ -76,7 +69,6 @@ struct ExplorerListeVue: View {
                 }
             }
         }
-        .environmentObject(vm)
     }
     
     private var sectionFiltreEtTri: some View {
@@ -155,9 +147,12 @@ struct ExplorerListeVue: View {
     )
     
     ExplorerListeVue(
-        utilisateur: .constant(mockUtilisateur),
-        serviceEmplacements: DonneesEmplacementService()
+        utilisateur: .constant(mockUtilisateur)
     )
     .environmentObject(ActivitesVM(serviceEmplacements: DonneesEmplacementService()))
     .environmentObject(AppVM())
+    .environmentObject(ExplorerListeVM(
+        serviceEmplacements: DonneesEmplacementService(),
+        serviceActivites: ServiceActivites()
+    ))
 }

--- a/SportLink/SportLink/Navigation/Explore/Views/ExplorerVue.swift
+++ b/SportLink/SportLink/Navigation/Explore/Views/ExplorerVue.swift
@@ -8,22 +8,30 @@
 import SwiftUI
 
 struct ExplorerVue: View {
-    @EnvironmentObject var serviceEmplacements: DonneesEmplacementService
+    let serviceEmplacements: DonneesEmplacementService
     @EnvironmentObject var activitesVM: ActivitesVM
+    @StateObject private var listeVM: ExplorerListeVM
     @State private var modeAffichage: ModeAffichage = .liste
     @Binding var utilisateur: Utilisateur
+
+    init(utilisateur: Binding<Utilisateur>, serviceEmplacements: DonneesEmplacementService) {
+        self._utilisateur = utilisateur
+        self.serviceEmplacements = serviceEmplacements
+        self._listeVM = StateObject(wrappedValue: ExplorerListeVM(
+            serviceEmplacements: serviceEmplacements,
+            serviceActivites: ServiceActivites()
+        ))
+    }
 
     var body: some View {
         ZStack {
             Group {
                 if modeAffichage == .liste {
-                    ExplorerListeVue(
-                        utilisateur: $utilisateur,
-                        serviceEmplacements: serviceEmplacements
-                    )
-                    .environmentObject(serviceEmplacements)
-                    .environmentObject(activitesVM)
-                    .transition(.move(edge: .leading))
+                    ExplorerListeVue(utilisateur: $utilisateur)
+                        .environmentObject(serviceEmplacements)
+                        .environmentObject(activitesVM)
+                        .environmentObject(listeVM)
+                        .transition(.move(edge: .leading))
                 } else {
                     ExplorerCarteVue(utilisateur: $utilisateur)
                         .environmentObject(serviceEmplacements)
@@ -53,7 +61,7 @@ struct ExplorerVue: View {
         partenairesRecents: []
     )
     
-    ExplorerVue(utilisateur: .constant(mockUtilisateur))
-        .environmentObject(DonneesEmplacementService())
+    ExplorerVue(utilisateur: .constant(mockUtilisateur), serviceEmplacements: DonneesEmplacementService())
         .environmentObject(ActivitesVM(serviceEmplacements: DonneesEmplacementService()))
+        .environmentObject(AppVM())
 }


### PR DESCRIPTION
## Summary
- Instantiate `ExplorerListeVM` once in `ExplorerVue` and pass it down so filter selections persist
- Update `ExplorerListeVue` to consume its view model from the environment instead of recreating it
- Adjust `VuePrincipale` to supply the services required by `ExplorerVue`

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689b5395e5f08326b25c95a0823f7063